### PR TITLE
Add launchd plist to formula

### DIFF
--- a/mopidy.rb
+++ b/mopidy.rb
@@ -46,4 +46,31 @@ class Mopidy < Formula
   def test
     system "python", "-c", "import mopidy"
   end
+
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/mopidy</string>
+      </array>
+      <key>EnvironmentVariables</key>
+      <dict>
+        <key>PYTHONPATH</key>
+        <string>/usr/local/lib/python2.7/site-packages</string>
+      </dict>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>KeepAlive</key>
+      <true/>
+      <key>WorkingDirectory</key>
+      <string>#{HOMEBREW_PREFIX}</string>
+    </dict>
+    </plist>
+    EOS
+  end
 end


### PR DESCRIPTION
Adds the launchd plist from mopidy/mopidy#887 to the mopidy formula.

After installing mopidy, the user will see instructions for daemonizing it with launchd:

```
==> Caveats
To have launchd start mopidy at login:
    ln -sfv /usr/local/opt/mopidy/*.plist ~/Library/LaunchAgents
Then to load mopidy now:
    launchctl load ~/Library/LaunchAgents/homebrew.mxcl.mopidy.plist
```
