### PR TITLE
Fixed mopidy depends_on "gst-plugins-good"

### DIFF
--- a/mopidy.rb
+++ b/mopidy.rb
@@ -13,9 +13,7 @@ class Mopidy < Formula
   ]
   depends_on "gst-plugins-good" => [
     "with-flac",
-    "with-jpeg",
     "with-libshout",
-    "with-libsoup",
     "with-speex",
     "with-taglib"
   ]


### PR DESCRIPTION
- Removed gst-plugins-good optional argument "with-libjpeg" since it has been removed from optional dependencies (https://github.com/Homebrew/homebrew-core/commit/caf5b98a8944e929f2e74193b5c478237a98d359#diff-b9139daf6f9171d789b2742aaad7dec4)
- Removed gst-plugins-good optional argument "with-libsoup" since it has been removed from optional dependencies (https://github.com/Homebrew/homebrew-core/commit/5ee23a1631632b31faea3b0717ca2bc575d5a9ee#diff-b9139daf6f9171d789b2742aaad7dec4)