### PR TITLE
Add opus plugins to gst-plugins-base

### DIFF
--- a/mopidy.rb
+++ b/mopidy.rb
@@ -9,6 +9,7 @@ class Mopidy < Formula
   depends_on "gst-plugins-base" => [
     "with-libogg",
     "with-libvorbis",
+    "with-opus",
     "with-theora"
   ]
   depends_on "gst-plugins-good" => [


### PR DESCRIPTION
Did not include the opusdec which made conflicts with mopidy-youtube from here https://github.com/mopidy/mopidy-youtube/issues/75

Tested locally and works ok!