### PR TITLE
Homebrew python dependency update

### DIFF
--- a/mopidy-dirble.rb
+++ b/mopidy-dirble.rb
@@ -5,7 +5,7 @@ class MopidyDirble < Formula
   sha256 "ac018cb8534d2baec1981406251e1d6f00d172577554eae0783bc4ee68c94661"
   head "https://github.com/mopidy/mopidy-dirble.git"
 
-  depends_on :python
+  depends_on "python"
   depends_on "mopidy/mopidy/mopidy"
   depends_on "mopidy/mopidy/python-pykka"
   depends_on "mopidy/mopidy/python-requests"

--- a/mopidy-notifier.rb
+++ b/mopidy-notifier.rb
@@ -5,7 +5,7 @@ class MopidyNotifier < Formula
   sha256 "2bb1ab9ade3633269a5b4ff765fafad5f61e1cebd74e6d0671b60b8ea7501990"
   head "https://github.com/sauberfred/mopidy-notifier.git"
 
-  depends_on :python
+  depends_on "python"
   depends_on "mopidy/mopidy/mopidy"
   depends_on "mopidy/mopidy/python-pykka"
   depends_on "terminal-notifier"

--- a/mopidy-scrobbler.rb
+++ b/mopidy-scrobbler.rb
@@ -5,7 +5,7 @@ class MopidyScrobbler < Formula
   sha256 "7951dcf4db088fe755145a16a853546fbf3cf7a408d2120d50580ed3db0a85c3"
   head "https://github.com/mopidy/mopidy-scrobbler.git"
 
-  depends_on :python
+  depends_on "python"
   depends_on "mopidy/mopidy/mopidy"
   depends_on "mopidy/mopidy/python-pykka"
   depends_on "mopidy/mopidy/python-pylast"

--- a/mopidy-soundcloud.rb
+++ b/mopidy-soundcloud.rb
@@ -5,7 +5,7 @@ class MopidySoundcloud < Formula
   sha256 "374bf7ab496623f787ad2905575fce52df437e953c876486e059d8cb9aecc509"
   head "https://github.com/mopidy/mopidy-soundcloud.git"
 
-  depends_on :python
+  depends_on "python"
   depends_on "mopidy/mopidy/mopidy"
   depends_on "mopidy/mopidy/python-pykka"
   depends_on "mopidy/mopidy/python-requests"

--- a/mopidy-spotify.rb
+++ b/mopidy-spotify.rb
@@ -5,7 +5,7 @@ class MopidySpotify < Formula
   sha256 "f5123a4ce310eca7d16fcb693839729249df86610ed779e7cea17927b3ac8b66"
   head "https://github.com/mopidy/mopidy-spotify.git"
 
-  depends_on :python
+  depends_on "python"
   depends_on "mopidy/mopidy/mopidy"
   depends_on "mopidy/mopidy/python-pykka"
   depends_on "mopidy/mopidy/python-requests"

--- a/mopidy.rb
+++ b/mopidy.rb
@@ -5,7 +5,7 @@ class Mopidy < Formula
   sha256 "297369a34ebd584b2fe25a7184f68fe876a149256549b03b503a55ede3f13f6a"
   head "https://github.com/mopidy/mopidy.git"
 
-  depends_on :python
+  depends_on "python"
   depends_on "gst-plugins-base" => [
     "with-libogg",
     "with-libvorbis",

--- a/python-backports-abc.rb
+++ b/python-backports-abc.rb
@@ -5,8 +5,8 @@ class PythonBackportsAbc < Formula
   sha256 "8b3e4092ba3d541c7a2f9b7d0d9c0275b21c6a01c53a61c731eba6686939d0a5"
   head "https://github.com/cython/backports_abc"
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
 
   def install
     Language::Python.each_python(build) do |python, _version|

--- a/python-backports-ssl-match-hostname.rb
+++ b/python-backports-ssl-match-hostname.rb
@@ -5,8 +5,8 @@ class PythonBackportsSslMatchHostname < Formula
   sha256 "502ad98707319f4a51fa2ca1c677bd659008d27ded9f6380c79e8932e38dcdf2"
   head "https://bitbucket.org/brandon/backports.ssl_match_hostname"
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
 
   def install
     Language::Python.each_python(build) do |python, _version|

--- a/python-certifi.rb
+++ b/python-certifi.rb
@@ -5,8 +5,8 @@ class PythonCertifi < Formula
   sha256 "99864ed602d8a9d212e339b15ffa438895002eda7b7db20dca5309dac9605ae9"
   head "https://github.com/certifi/python-certifi.git"
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
 
   def install
     Language::Python.each_python(build) do |python, _version|

--- a/python-cffi.rb
+++ b/python-cffi.rb
@@ -5,8 +5,8 @@ class PythonCffi < Formula
   sha256 "6ed5dd6afd8361f34819c68aaebf9e8fc12b5a5893f91f50c9e50c8886bb60df"
   head "https://bitbucket.org/cffi/cffi", :using => :hg
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
   depends_on "libffi"
   depends_on "mopidy/mopidy/python-pycparser"
 

--- a/python-pycparser.rb
+++ b/python-pycparser.rb
@@ -5,8 +5,8 @@ class PythonPycparser < Formula
   sha256 "7959b4a74abdc27b312fed1c21e6caf9309ce0b29ea86b591fd2e99ecdf27f73"
   head "https://github.com/eliben/pycparser.git"
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
 
   def install
     Language::Python.each_python(build) do |python, _version|

--- a/python-pykka.rb
+++ b/python-pykka.rb
@@ -5,8 +5,8 @@ class PythonPykka < Formula
   sha256 "e847ffeadee49b563426ab803e8eee67264d773e38ca14763fdcda56411e3c11"
   head "https://github.com/jodal/pykka.git"
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
 
   def install
     Language::Python.each_python(build) do |python, _version|

--- a/python-pylast.rb
+++ b/python-pylast.rb
@@ -5,8 +5,8 @@ class PythonPylast < Formula
   sha256 "85f8dd96aef0ccba5f80379c3d7bc1fabd72f59aebab040daf40a8b72268f9bd"
   head "https://github.com/pylast/pylast.git"
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
 
   def install
     Language::Python.each_python(build) do |python, _version|

--- a/python-requests.rb
+++ b/python-requests.rb
@@ -5,8 +5,8 @@ class PythonRequests < Formula
   sha256 "b2ff053e93ef11ea08b0e596a1618487c4e4c5f1006d7a1706e3671c57dea385"
   head "https://github.com/kennethreitz/requests.git"
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
 
   def install
     Language::Python.each_python(build) do |python, _version|

--- a/python-singledispatch.rb
+++ b/python-singledispatch.rb
@@ -5,8 +5,8 @@ class PythonSingledispatch < Formula
   sha256 "5b06af87df13818d14f08a028e42f566640aef80805c3b50c5056b086e3c2b9c"
   head "https://bitbucket.org/ambv/singledispatch", :using => :hg
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
   depends_on "mopidy/mopidy/python-six"
 
   def install

--- a/python-six.rb
+++ b/python-six.rb
@@ -5,8 +5,8 @@ class PythonSix < Formula
   sha256 "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
   head "https://bitbucket.org/gutworth/six", :using => :hg
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
 
   def install
     Language::Python.each_python(build) do |python, _version|

--- a/python-spotify.rb
+++ b/python-spotify.rb
@@ -5,7 +5,7 @@ class PythonSpotify < Formula
   sha256 "fbd41c58d62232b0cabb7a9e38d45f36ac221699c006899bdb6be74c04602678"
   head "https://github.com/mopidy/pyspotify.git", :branch => "v2.x/develop"
 
-  depends_on :python
+  depends_on "python"
   depends_on "mopidy/mopidy/libspotify"
   depends_on "mopidy/mopidy/python-cffi"
 

--- a/python-tornado.rb
+++ b/python-tornado.rb
@@ -5,8 +5,8 @@ class PythonTornado < Formula
   sha256 "371d0cf3d56c47accc66116a77ad558d76eebaa8458a6b677af71ca606522146"
   head "https://github.com/tornadoweb/tornado.git"
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
   depends_on "mopidy/mopidy/python-backports-abc"
   depends_on "mopidy/mopidy/python-backports-ssl-match-hostname"
   depends_on "mopidy/mopidy/python-certifi"


### PR DESCRIPTION
Use depends_on "python" and depends_on "python3" instead of the now deprecated depends_on :python and depends_on :python3
Fix #19