### PR TITLE
fix gst-python wrapper for homebrewed python changes

### DIFF
--- a/mopidy.rb
+++ b/mopidy.rb
@@ -33,7 +33,10 @@ class Mopidy < Formula
     "with-theora",
     "with-two-lame"
   ]
-  depends_on "gst-python"
+  depends_on "gst-python" => [
+    "without-python",
+    "with-python@2"
+  ]
   depends_on "mopidy/mopidy/python-pykka"
   depends_on "mopidy/mopidy/python-tornado"
   depends_on "mopidy/mopidy/python-requests"


### PR DESCRIPTION
gst-python wrapper needs to built with specific params now on newly homebrewed machines, per https://brew.sh/2018/01/19/homebrew-1.5.0/

fixes 

```
ERROR: A GObject Python package was not found.

Mopidy requires GStreamer to work. GStreamer is a C library with a
number of dependencies itself, and cannot be installed with the regular
Python tools like pip.

Please see http://docs.mopidy.com/en/latest/installation/ for
instructions on how to install the required dependencies.

Traceback (most recent call last):
  File "/usr/local/bin/mopidy", line 11, in <module>
    load_entry_point('Mopidy==2.1.0', 'console_scripts', 'mopidy')()
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 480, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2693, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2324, in load
    return self.resolve()
  File "/usr/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2330, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python2.7/site-packages/mopidy/__main__.py", line 8, in <module>
    from mopidy.internal.gi import Gst  # noqa: F401
  File "/usr/local/lib/python2.7/site-packages/mopidy/internal/gi.py", line 8, in <module>
    import gi
```

