### PR TITLE
Fixed brew warning

### DIFF
--- a/mopidy.rb
+++ b/mopidy.rb
@@ -52,7 +52,7 @@ class Mopidy < Formula
     "homebrew.mopidy." + name
   end
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
     <plist version="1.0">


### PR DESCRIPTION
```bash
brew services list
Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
```