### PR TITLE
fix deprecated syntax from <<-EOS.undent to <<~EOS

### DIFF
--- a/libspotify.rb
+++ b/libspotify.rb
@@ -18,7 +18,7 @@ class Libspotify < Formula
     lib.install_symlink "libspotify.12.1.51.dylib" => "libspotify"
   end
 
-  def pc_file; <<-EOS.undent
+  def pc_file; <<~EOS
     prefix=#{opt_prefix}
     exec_prefix=${prefix}
     libdir=${exec_prefix}/lib
@@ -33,7 +33,7 @@ class Libspotify < Formula
   end
 
   test do
-    (testpath/"test.c").write <<-EOS.undent
+    (testpath/"test.c").write <<~EOS
       #include <string.h>
       #include <libspotify/api.h>
 


### PR DESCRIPTION
On installing `mopidy-spotify`, homebrew throws the following error:

```
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/mopidy/homebrew-mopidy/libspotify.rb:32:in `pc_file'
```

This PR just fixes 2 instances of the deprecated syntax