### PR TITLE
Missing dependency py2cairo

### DIFF
--- a/Formula/mopidy.rb
+++ b/Formula/mopidy.rb
@@ -34,6 +34,7 @@ class Mopidy < Formula
     "with-theora",
     "with-two-lame",
   ]
+  depends_on "py2cairo"
   depends_on "gst-python" => [
     "without-python",
     "with-python@2",


### PR DESCRIPTION
There is an error when installing mopidy on Mac OS 10.13.5 (cf. https://github.com/mopidy/mopidy/issues/1675):

```
brew tap mopidy/mopidy
brew install mopidy
...
==> Installing mopidy/mopidy/mopidy dependency: pygobject3
==> Downloading https://homebrew.bintray.com/bottles/pygobject3-3.28.3.high_sierra.bottle.tar.gz
==> Downloading from https://akamai.bintray.com/94/94fae679989e058565619b7ad90481efe90512ccf90835c823aa35be1d0f379f?__gda__=exp=1529860965~hmac=11466145868934f199c2f2e0dec765
######################################################################## 100.0%
==> Pouring pygobject3-3.28.3.high_sierra.bottle.tar.gz
🍺  /usr/local/Cellar/pygobject3/3.28.3: 36 files, 2MB
==> Installing mopidy/mopidy/mopidy dependency: gst-python
Error: /usr/local/opt/py2cairo not present or broken
Please reinstall py2cairo. Sorry :(
```

This is easily solved by running `brew install py2cairo` before running `brew install mopidy`. Probably this should be a dependency.

I'm not so sure what exactly fails here. It seems as `gst-python` is the culprit. However, if I uninstall `py2cairo` and `gst-python` and reinstall `gst-python`, that works without any problems. I guess `py2cairo` thus needs to be a dependency of mobidy and not `gst-python`?