### PR TITLE
Migrate everything to 3.9

### DIFF
--- a/Formula/mopidy-beets.rb
+++ b/Formula/mopidy-beets.rb
@@ -4,9 +4,9 @@ class MopidyBeets < Formula
   url "https://files.pythonhosted.org/packages/0e/59/72ac45e8a6b37a81d89df24052275c6a313bdcdde23eb7b6ce130433854d/Mopidy-Beets-4.0.0.tar.gz"
   sha256 "c7455617e3f96c893181aec41b54d4b5a54daf1514ea6d2313abb69bfb78e186"
   head "https://github.com/mopidy/mopidy-beets.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -14,7 +14,7 @@ class MopidyBeets < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, *Language::Python.setup_install_args(libexec)
 
     xy = Language::Python.major_minor_version python3
@@ -24,7 +24,7 @@ class MopidyBeets < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import mopidy_beets"
   end
 end

--- a/Formula/mopidy-internetarchive.rb
+++ b/Formula/mopidy-internetarchive.rb
@@ -4,9 +4,9 @@ class MopidyInternetarchive < Formula
   url "https://files.pythonhosted.org/packages/e3/4a/159fd84d3f4d4ece603ebbb3f5e0ca0192084e9b5da5fcdab7eebb87e902/Mopidy-InternetArchive-3.0.0.tar.gz"
   sha256 "bbd1fbcddfa06caaa088a3bf3533d4a7aa8bc8f4e4b11019b4664cc8426e7363"
   head "https://github.com/tkem/mopidy-internetarchive.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -24,7 +24,7 @@ class MopidyInternetarchive < Formula
   end
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
 
     resources.each do |r|
       r.stage do
@@ -41,7 +41,7 @@ class MopidyInternetarchive < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import mopidy_internetarchive"
   end
 end

--- a/Formula/mopidy-local.rb
+++ b/Formula/mopidy-local.rb
@@ -4,9 +4,9 @@ class MopidyLocal < Formula
   url "https://files.pythonhosted.org/packages/03/a9/650dfbd029d38ff38b8bd1c8516ae91272a800f60d1289746cd070ba7b01/Mopidy-Local-3.1.1.tar.gz"
   sha256 "3205082a4543ecf38378b34e30344dc892bdb18ed73d93eab5f47a4ac28fa08e"
   head "https://github.com/mopidy/mopidy-local.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -19,7 +19,7 @@ class MopidyLocal < Formula
   end
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
 
     resources.each do |r|
       r.stage do
@@ -36,7 +36,7 @@ class MopidyLocal < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import mopidy_local"
   end
 end

--- a/Formula/mopidy-mpd.rb
+++ b/Formula/mopidy-mpd.rb
@@ -4,9 +4,9 @@ class MopidyMpd < Formula
   url "https://files.pythonhosted.org/packages/10/a1/af1f72d84b07fbc9353b5c4a37540b59ee5072fcc2f1791f81386046f1f9/Mopidy-MPD-3.0.0.tar.gz"
   sha256 "4c452e8ad8fbf13322b510cd48bc5bef5779d2ac8f39cd5e0ca2883248a4325f"
   head "https://github.com/mopidy/mopidy-mpd.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -14,7 +14,7 @@ class MopidyMpd < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
 
     resources.each do |r|
       r.stage do
@@ -31,7 +31,7 @@ class MopidyMpd < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import mopidy_mpd"
   end
 end

--- a/Formula/mopidy-podcast-itunes.rb
+++ b/Formula/mopidy-podcast-itunes.rb
@@ -4,9 +4,9 @@ class MopidyPodcastItunes < Formula
   url "https://files.pythonhosted.org/packages/95/95/cdd4c37233d5653ce65a3ae35e56196a8815c789a2c624c88d603bd11008/Mopidy-Podcast-iTunes-3.0.0.tar.gz"
   sha256 "11b0faf4d099336bb63afe7478ee1d387aeb2c6552a275b196c351a62e65b2e6"
   head "https://github.com/tkem/mopidy-podcast-itunes.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "mopidy/mopidy/mopidy"
   depends_on "mopidy/mopidy/mopidy-podcast"
 
@@ -15,7 +15,7 @@ class MopidyPodcastItunes < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, *Language::Python.setup_install_args(libexec)
 
     xy = Language::Python.major_minor_version python3
@@ -25,7 +25,7 @@ class MopidyPodcastItunes < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import mopidy_podcast_itunes"
   end
 end

--- a/Formula/mopidy-podcast.rb
+++ b/Formula/mopidy-podcast.rb
@@ -4,9 +4,9 @@ class MopidyPodcast < Formula
   url "https://files.pythonhosted.org/packages/2a/88/c40f0e727d20849ae67f247a4aa0dd5bcac7f76e27f613cbaf187f5c68bc/Mopidy-Podcast-3.0.0.tar.gz"
   sha256 "b9e360b817aa53d700909860f87ba58500ae76fe6c9e7a2e72ecb6ed87284bfc"
   head "https://github.com/tkem/mopidy-podcast.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -24,7 +24,7 @@ class MopidyPodcast < Formula
   end
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
 
     resources.each do |r|
       r.stage do
@@ -41,7 +41,7 @@ class MopidyPodcast < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import mopidy_podcast"
   end
 end

--- a/Formula/mopidy-scrobbler.rb
+++ b/Formula/mopidy-scrobbler.rb
@@ -4,9 +4,9 @@ class MopidyScrobbler < Formula
   url "https://files.pythonhosted.org/packages/78/30/8ca1603b687a37b3773f574c5a419d7eea659d52f4018a93c46471998da1/Mopidy-Scrobbler-2.0.0.tar.gz"
   sha256 "2411e92303cd5950f5a24ef476638bffc066b43f79e7422b3727b7e120e91d69"
   head "https://github.com/mopidy/mopidy-scrobbler.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -18,7 +18,7 @@ class MopidyScrobbler < Formula
   end
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
 
     resources.each do |r|
       r.stage do
@@ -35,7 +35,7 @@ class MopidyScrobbler < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import mopidy_scrobbler"
   end
 end

--- a/Formula/mopidy-somafm.rb
+++ b/Formula/mopidy-somafm.rb
@@ -4,9 +4,9 @@ class MopidySomafm < Formula
   url "https://files.pythonhosted.org/packages/f3/07/a29f0fa2f26d9948ea449f1a415cd459b47d48adfdef176fd99553cf81ac/Mopidy-SomaFM-2.0.0.tar.gz"
   sha256 "c3d1ae99867e09041f1d6565b218a5792f8438ee6196b1ecc610691f69ce08c9"
   head "https://github.com/AlexandrePTJ/mopidy-somafm.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -14,7 +14,7 @@ class MopidySomafm < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
 
     system python3, *Language::Python.setup_install_args(libexec)
 
@@ -25,7 +25,7 @@ class MopidySomafm < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import mopidy_somafm"
   end
 end

--- a/Formula/mopidy-soundcloud.rb
+++ b/Formula/mopidy-soundcloud.rb
@@ -4,9 +4,9 @@ class MopidySoundcloud < Formula
   url "https://files.pythonhosted.org/packages/83/55/58ddb9770ed9bd0fcf765a486f15261d78265562bf208f9dc3f5dab55166/Mopidy-SoundCloud-3.0.0.tar.gz"
   sha256 "9c1732d6f06a71f8573b035c5b920dfa3448e7681dba882394e664fdf5d80197"
   head "https://github.com/mopidy/mopidy-soundcloud.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -14,7 +14,7 @@ class MopidySoundcloud < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
 
     system python3, *Language::Python.setup_install_args(libexec)
 
@@ -25,7 +25,7 @@ class MopidySoundcloud < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import mopidy_soundcloud"
   end
 end

--- a/Formula/mopidy-spotify.rb
+++ b/Formula/mopidy-spotify.rb
@@ -4,9 +4,9 @@ class MopidySpotify < Formula
   url "https://files.pythonhosted.org/packages/f2/d2/0ce7f0f948fa91175bc34b23be9c4c70323d121acb4cc089bd72fc2769df/Mopidy-Spotify-4.0.1.tar.gz"
   sha256 "ab437903b9fee931864d62ba03af5d2517dd844f4c8476e1ba26b280daf40508"
   head "https://github.com/mopidy/mopidy-spotify.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "mopidy/mopidy/mopidy"
   depends_on "mopidy/mopidy/pyspotify"
 
@@ -15,7 +15,7 @@ class MopidySpotify < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
 
     system python3, *Language::Python.setup_install_args(libexec)
 
@@ -26,7 +26,7 @@ class MopidySpotify < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import mopidy_spotify"
   end
 end

--- a/Formula/mopidy-tunein.rb
+++ b/Formula/mopidy-tunein.rb
@@ -4,9 +4,9 @@ class MopidyTunein < Formula
   url "https://files.pythonhosted.org/packages/06/57/bc06f47a2d5e716b15bc3b74d859854386dd5c9ebf7d73a025c32d267945/Mopidy-TuneIn-1.0.0.tar.gz"
   sha256 "d261730b918db2d81af204ee42c40d33d73fefe9aafe0225d652214e9c56da46"
   head "https://github.com/kingosticks/mopidy-tunein.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -14,7 +14,7 @@ class MopidyTunein < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
 
     system python3, *Language::Python.setup_install_args(libexec)
 
@@ -25,7 +25,7 @@ class MopidyTunein < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import mopidy_tunein"
   end
 end

--- a/Formula/mopidy.rb
+++ b/Formula/mopidy.rb
@@ -4,9 +4,9 @@ class Mopidy < Formula
   url "https://files.pythonhosted.org/packages/b0/6f/eaadbe67c5b99215bfa247257fc20cb997674f5ecf3765230ae92d456a74/Mopidy-3.0.2.tar.gz"
   sha256 "60b6f48e53069ac280e8271e89f50161d8a3e0c9bee83ac4d862174b3e38cedb"
   head "https://github.com/mopidy/mopidy.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "gst-plugins-base"
   depends_on "gst-plugins-good"
   depends_on "gst-plugins-bad"
@@ -56,7 +56,7 @@ class Mopidy < Formula
   end
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
 
     resources.each do |r|
       r.stage do
@@ -96,7 +96,7 @@ class Mopidy < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import mopidy"
   end
 

--- a/Formula/pyspotify.rb
+++ b/Formula/pyspotify.rb
@@ -4,9 +4,9 @@ class Pyspotify < Formula
   url "https://files.pythonhosted.org/packages/fe/1d/83d088397d95eacf6281ae748886d024aab50efdea50aedf8f294fc53aa7/pyspotify-2.1.3.tar.gz"
   sha256 "6ae31d8ccd7e1f138a80f08c766173b2ced12d196732f68aee4ae023b7a9ad2a"
   head "https://github.com/mopidy/pyspotify.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.8"
+  depends_on "python@3.9"
   depends_on "libffi"
   depends_on "mopidy/mopidy/libspotify"
 
@@ -21,7 +21,7 @@ class Pyspotify < Formula
   end
 
   def install
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
 
     resources.each do |r|
       r.stage do
@@ -38,7 +38,7 @@ class Pyspotify < Formula
   end
 
   test do
-    python3 = Formula["python@3.8"].opt_bin/"python3"
+    python3 = Formula["python@3.9"].opt_bin/"python3"
     system python3, "-c", "import spotify"
   end
 end


### PR DESCRIPTION
Homebrew has yet again done a upgrade which breaks everything.

So we must upgrade to 3.9 if we want anything to work at all. It's #35 et.al. all over again...