### PR TITLE
Mopidy 3.4.2

### DIFF
--- a/Formula/mopidy-beets.rb
+++ b/Formula/mopidy-beets.rb
@@ -4,9 +4,9 @@ class MopidyBeets < Formula
   url "https://files.pythonhosted.org/packages/43/76/26231228ba3eb99875d94c3eddcc519c32f62ed39acaeec5fb8df4211997/Mopidy-Beets-4.0.1.tar.gz"
   sha256 "6a3310f12da35bd737763ffbe7bab2301ad8340d74470d222817d2c39ba2a0d1"
   head "https://github.com/mopidy/mopidy-beets.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -14,7 +14,7 @@ class MopidyBeets < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, *Language::Python.setup_install_args(libexec)
 
     xy = Language::Python.major_minor_version python3
@@ -24,7 +24,7 @@ class MopidyBeets < Formula
   end
 
   test do
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, "-c", "import mopidy_beets"
   end
 end

--- a/Formula/mopidy-internetarchive.rb
+++ b/Formula/mopidy-internetarchive.rb
@@ -4,8 +4,9 @@ class MopidyInternetarchive < Formula
   url "https://files.pythonhosted.org/packages/21/9c/98fd4ec4372605187fca0fad02b98e341ec97bb2f63385cc9a379850944c/Mopidy-InternetArchive-3.0.1.tar.gz"
   sha256 "800efa2ccf0c6e99e1eec8599d6f7fc31f153c6c5a2028083c38b4a90884d10a"
   head "https://github.com/tkem/mopidy-internetarchive.git"
+  revision 1
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -23,7 +24,7 @@ class MopidyInternetarchive < Formula
   end
 
   def install
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
     resources.each do |r|
       r.stage do
@@ -40,7 +41,7 @@ class MopidyInternetarchive < Formula
   end
 
   test do
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, "-c", "import mopidy_internetarchive"
   end
 end

--- a/Formula/mopidy-local.rb
+++ b/Formula/mopidy-local.rb
@@ -4,8 +4,9 @@ class MopidyLocal < Formula
   url "https://files.pythonhosted.org/packages/06/c3/5426543db3a53285ab1e45ad5e3ca261a41db20838ce68038c4ee0f7d41d/Mopidy-Local-3.2.1.tar.gz"
   sha256 "29165157134fe869228da675e4d0083888368a29dc7dd3203fe1a27d7b4d83a3"
   head "https://github.com/mopidy/mopidy-local.git"
+  revision 1
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -18,7 +19,7 @@ class MopidyLocal < Formula
   end
 
   def install
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
     resources.each do |r|
       r.stage do
@@ -35,7 +36,7 @@ class MopidyLocal < Formula
   end
 
   test do
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, "-c", "import mopidy_local"
   end
 end

--- a/Formula/mopidy-mpd.rb
+++ b/Formula/mopidy-mpd.rb
@@ -4,8 +4,9 @@ class MopidyMpd < Formula
   url "https://files.pythonhosted.org/packages/8a/45/2ae38c8e83c7e7fd49bda4ce2ee3cd7b2454837ab763a5be192ac657bf98/Mopidy-MPD-3.3.0.tar.gz"
   sha256 "09e2cc46a8fd73006f42b3b1ed71d557c3230e3c0ea2c38d565b0dda8faf4d53"
   head "https://github.com/mopidy/mopidy-mpd.git"
+  revision 1
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -13,7 +14,7 @@ class MopidyMpd < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
     resources.each do |r|
       r.stage do
@@ -30,7 +31,7 @@ class MopidyMpd < Formula
   end
 
   test do
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, "-c", "import mopidy_mpd"
   end
 end

--- a/Formula/mopidy-podcast-itunes.rb
+++ b/Formula/mopidy-podcast-itunes.rb
@@ -4,8 +4,9 @@ class MopidyPodcastItunes < Formula
   url "https://files.pythonhosted.org/packages/da/37/c056afd9471c0d32ee116ed1f0977c6bc45a1bee2bd5b47e339f198118be/Mopidy-Podcast-iTunes-3.0.1.tar.gz"
   sha256 "b31a30447506894afb74aa0d2ace21b4525c704681aafcafcc8366ad921921db"
   head "https://github.com/tkem/mopidy-podcast-itunes.git"
+  revision 1
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "mopidy/mopidy/mopidy"
   depends_on "mopidy/mopidy/mopidy-podcast"
 
@@ -14,7 +15,7 @@ class MopidyPodcastItunes < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, *Language::Python.setup_install_args(libexec)
 
     xy = Language::Python.major_minor_version python3
@@ -24,7 +25,7 @@ class MopidyPodcastItunes < Formula
   end
 
   test do
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, "-c", "import mopidy_podcast_itunes"
   end
 end

--- a/Formula/mopidy-podcast.rb
+++ b/Formula/mopidy-podcast.rb
@@ -4,8 +4,9 @@ class MopidyPodcast < Formula
   url "https://files.pythonhosted.org/packages/66/0e/84b848db511b8bbd1a3b7b32fb36656956e98a4069b3b41249db93b7f548/Mopidy-Podcast-3.0.1.tar.gz"
   sha256 "82b34f54454cd8f9696210577bab1a6c58d6541f7eabe6a92118dc1d4c47e760"
   head "https://github.com/tkem/mopidy-podcast.git"
+  revision 1
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -23,7 +24,7 @@ class MopidyPodcast < Formula
   end
 
   def install
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
     resources.each do |r|
       r.stage do
@@ -40,7 +41,7 @@ class MopidyPodcast < Formula
   end
 
   test do
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, "-c", "import mopidy_podcast"
   end
 end

--- a/Formula/mopidy-scrobbler.rb
+++ b/Formula/mopidy-scrobbler.rb
@@ -4,9 +4,9 @@ class MopidyScrobbler < Formula
   url "https://files.pythonhosted.org/packages/4b/2b/f5e71a37ca6698e4f287384482601b869d48fefeed8823b5db87a358bcfc/Mopidy-Scrobbler-2.0.1.tar.gz"
   sha256 "001920edc5433678091cb74c56e39c57ffcdb280396447b07d6fbe4eba7a7d87"
   head "https://github.com/mopidy/mopidy-scrobbler.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -18,7 +18,7 @@ class MopidyScrobbler < Formula
   end
 
   def install
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
     resources.each do |r|
       r.stage do
@@ -35,7 +35,7 @@ class MopidyScrobbler < Formula
   end
 
   test do
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, "-c", "import mopidy_scrobbler"
   end
 end

--- a/Formula/mopidy-somafm.rb
+++ b/Formula/mopidy-somafm.rb
@@ -4,8 +4,9 @@ class MopidySomafm < Formula
   url "https://files.pythonhosted.org/packages/0e/6a/4cc6c5d1c813ec98343f24be7df3318acf118d2920ceeea6b6d31da1f1f0/Mopidy-SomaFM-2.0.2.tar.gz"
   sha256 "0c2d1e9b192859f8c61e28760bc9c8341141c9fe76d577fedcab38251c4d3cb3"
   head "https://github.com/AlexandrePTJ/mopidy-somafm.git"
+  revision 1
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -13,7 +14,7 @@ class MopidySomafm < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
     system python3, *Language::Python.setup_install_args(libexec)
 
@@ -24,7 +25,7 @@ class MopidySomafm < Formula
   end
 
   test do
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, "-c", "import mopidy_somafm"
   end
 end

--- a/Formula/mopidy-soundcloud.rb
+++ b/Formula/mopidy-soundcloud.rb
@@ -4,8 +4,9 @@ class MopidySoundcloud < Formula
   url "https://files.pythonhosted.org/packages/84/59/6e556a8c0c5203228a4dad056b2cfd7b2a2a4f737fa740ed436a4b5772ee/Mopidy-SoundCloud-3.0.2.tar.gz"
   sha256 "783ac1459750c9d157bd9d097e486199a16838d6eb1268dd8a642ae37a15f3e2"
   head "https://github.com/mopidy/mopidy-soundcloud.git"
+  revision 1
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -13,7 +14,7 @@ class MopidySoundcloud < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
     system python3, *Language::Python.setup_install_args(libexec)
 
@@ -24,7 +25,7 @@ class MopidySoundcloud < Formula
   end
 
   test do
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, "-c", "import mopidy_soundcloud"
   end
 end

--- a/Formula/mopidy-spotify.rb
+++ b/Formula/mopidy-spotify.rb
@@ -4,8 +4,9 @@ class MopidySpotify < Formula
   url "https://files.pythonhosted.org/packages/dc/9c/abd89195770fa8a7b7835f23b41657a0eddf13b58512a916da2dfd126d92/Mopidy-Spotify-4.1.1.tar.gz"
   sha256 "e137d0675288e48563c15d50cb2722c618f1a085673f96b620e64fafdaab97af"
   head "https://github.com/mopidy/mopidy-spotify.git"
+  revision 1
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -13,7 +14,7 @@ class MopidySpotify < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
     system python3, *Language::Python.setup_install_args(libexec)
 
@@ -24,7 +25,7 @@ class MopidySpotify < Formula
   end
 
   test do
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, "-c", "import mopidy_spotify"
   end
 end

--- a/Formula/mopidy-tunein.rb
+++ b/Formula/mopidy-tunein.rb
@@ -4,9 +4,9 @@ class MopidyTunein < Formula
   url "https://files.pythonhosted.org/packages/22/c4/7efb36a75643a249528f191d1a9a130d9d62e4907aa35f4f9853e1fe1dd2/Mopidy-TuneIn-1.1.0.tar.gz"
   sha256 "910a96552d239bfaee6ef3635cf9018f7ef733ac311cd0b11f27334dbd56c107"
   head "https://github.com/kingosticks/mopidy-tunein.git"
-  revision 1
+  revision 2
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "mopidy/mopidy/mopidy"
 
   # Dependencies assumed bundled by mopidy:
@@ -14,7 +14,7 @@ class MopidyTunein < Formula
   # - requests
 
   def install
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
     system python3, *Language::Python.setup_install_args(libexec)
 
@@ -25,7 +25,7 @@ class MopidyTunein < Formula
   end
 
   test do
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, "-c", "import mopidy_tunein"
   end
 end

--- a/Formula/mopidy.rb
+++ b/Formula/mopidy.rb
@@ -4,8 +4,9 @@ class Mopidy < Formula
   url "https://files.pythonhosted.org/packages/c1/43/b450251b22c3b620a0f12bf7cb60db2ae160c5c535ce5dbe09c8ac35e1e3/Mopidy-3.4.1.tar.gz"
   sha256 "5c047be65738924e0349357dc46cb159b7cfbe7ed8dd2c9f3ee750e30c7a459a"
   head "https://github.com/mopidy/mopidy.git"
+  revision 1
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "gst-plugins-base"
   depends_on "gst-plugins-good"
   depends_on "gst-plugins-bad"
@@ -48,7 +49,7 @@ class Mopidy < Formula
   end
 
   def install
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
     resources.each do |r|
       r.stage do
@@ -72,7 +73,7 @@ class Mopidy < Formula
   end
 
   test do
-    python3 = Formula["python@3.11"].opt_bin/"python3.11"
+    python3 = Formula["python@3.12"].opt_bin/"python3.12"
     system python3, "-c", "import mopidy"
   end
 end

--- a/Formula/mopidy.rb
+++ b/Formula/mopidy.rb
@@ -1,26 +1,21 @@
 class Mopidy < Formula
   desc "Extensible music server written in Python"
   homepage "https://mopidy.com/"
-  url "https://files.pythonhosted.org/packages/c1/43/b450251b22c3b620a0f12bf7cb60db2ae160c5c535ce5dbe09c8ac35e1e3/Mopidy-3.4.1.tar.gz"
-  sha256 "5c047be65738924e0349357dc46cb159b7cfbe7ed8dd2c9f3ee750e30c7a459a"
+  url "https://files.pythonhosted.org/packages/cc/41/1f291572997c49fce9eef47cea6d06b7d30e9923cc75a84679767f7fc99e/Mopidy-3.4.2.tar.gz"
+  sha256 "ada9ecbfc09eecc8c9e6742a8a4fea1632a134a1ab060527d8aa3d36df0547b6"
   head "https://github.com/mopidy/mopidy.git"
-  revision 1
 
   depends_on "python@3.12"
-  depends_on "gst-plugins-base"
-  depends_on "gst-plugins-good"
-  depends_on "gst-plugins-bad"
-  depends_on "gst-plugins-ugly"
-  depends_on "gst-python"
+  depends_on "gstreamer"
 
   resource "certifi" do
-    url "https://files.pythonhosted.org/packages/37/f7/2b1b0ec44fdc30a3d31dfebe52226be9ddc40cd6c0f34ffc8923ba423b69/certifi-2022.12.7.tar.gz"
-    sha256 "35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"
+    url "https://files.pythonhosted.org/packages/71/da/e94e26401b62acd6d91df2b52954aceb7f561743aa5ccc32152886c76c96/certifi-2024.2.2.tar.gz"
+    sha256 "0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"
   end
 
   resource "charset-normalizer" do
-    url "https://files.pythonhosted.org/packages/ff/d7/8d757f8bd45be079d76309248845a04f09619a7b17d6dfc8c9ff6433cac2/charset-normalizer-3.1.0.tar.gz"
-    sha256 "34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5"
+    url "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz"
+    sha256 "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
   end
 
   resource "idna" do
@@ -34,18 +29,18 @@ class Mopidy < Formula
   end
 
   resource "requests" do
-    url "https://files.pythonhosted.org/packages/9d/ee/391076f5937f0a8cdf5e53b701ffc91753e87b07d66bae4a09aa671897bf/requests-2.28.2.tar.gz"
-    sha256 "98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"
+    url "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz"
+    sha256 "942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
   end
 
   resource "tornado" do
-    url "https://files.pythonhosted.org/packages/f3/9e/225a41452f2d9418d89be5e32cf824c84fe1e639d350d6e8d49db5b7f73a/tornado-6.2.tar.gz"
-    sha256 "9b630419bde84ec666bfd7ea0a4cb2a8a651c2d5cccdbdd1972a0c859dfc3c13"
+    url "https://files.pythonhosted.org/packages/bd/a2/ea124343e3b8dd7712561fe56c4f92eda26865f5e1040b289203729186f2/tornado-6.4.tar.gz"
+    sha256 "72291fa6e6bc84e626589f1c29d90a5a6d593ef5ae68052ee2ef000dfd273dee"
   end
 
   resource "urllib3" do
-    url "https://files.pythonhosted.org/packages/21/79/6372d8c0d0641b4072889f3ff84f279b738cd8595b64c8e0496d4e848122/urllib3-1.26.15.tar.gz"
-    sha256 "8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305"
+    url "https://files.pythonhosted.org/packages/0c/39/64487bf07df2ed854cc06078c27c0d0abc59bd27b32232876e403c333a08/urllib3-1.26.18.tar.gz"
+    sha256 "f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
   end
 
   def install


### PR DESCRIPTION
Update Mopidy to 3.4.2. This also updates Python to 3.12, as I couldn't get Mopidy running under 3.11 for some reason.