### PR TITLE
Specify the python version when installing

### DIFF
--- a/Formula/mopidy-beets.rb
+++ b/Formula/mopidy-beets.rb
@@ -15,7 +15,7 @@ class MopidyBeets < Formula
 
   def install
     python3 = Formula["python@3.12"].opt_bin/"python3.12"
-    system python3, *Language::Python.setup_install_args(libexec)
+    system python3, *Language::Python.setup_install_args(libexec, python=python3)
 
     xy = Language::Python.major_minor_version python3
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/mopidy-internetarchive.rb
+++ b/Formula/mopidy-internetarchive.rb
@@ -28,11 +28,11 @@ class MopidyInternetarchive < Formula
 
     resources.each do |r|
       r.stage do
-        system python3, *Language::Python.setup_install_args(libexec)
+        system python3, *Language::Python.setup_install_args(libexec, python=python3)
       end
     end
 
-    system python3, *Language::Python.setup_install_args(libexec)
+    system python3, *Language::Python.setup_install_args(libexec, python=python3)
 
     xy = Language::Python.major_minor_version python3
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/mopidy-local.rb
+++ b/Formula/mopidy-local.rb
@@ -23,11 +23,11 @@ class MopidyLocal < Formula
 
     resources.each do |r|
       r.stage do
-        system python3, *Language::Python.setup_install_args(libexec)
+        system python3, *Language::Python.setup_install_args(libexec, python=python3)
       end
     end
 
-    system python3, *Language::Python.setup_install_args(libexec)
+    system python3, *Language::Python.setup_install_args(libexec, python=python3)
 
     xy = Language::Python.major_minor_version python3
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/mopidy-mpd.rb
+++ b/Formula/mopidy-mpd.rb
@@ -18,11 +18,11 @@ class MopidyMpd < Formula
 
     resources.each do |r|
       r.stage do
-        system python3, *Language::Python.setup_install_args(libexec)
+        system python3, *Language::Python.setup_install_args(libexec, python=python3)
       end
     end
 
-    system python3, *Language::Python.setup_install_args(libexec)
+    system python3, *Language::Python.setup_install_args(libexec, python=python3)
 
     xy = Language::Python.major_minor_version python3
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/mopidy-podcast-itunes.rb
+++ b/Formula/mopidy-podcast-itunes.rb
@@ -16,7 +16,7 @@ class MopidyPodcastItunes < Formula
 
   def install
     python3 = Formula["python@3.12"].opt_bin/"python3.12"
-    system python3, *Language::Python.setup_install_args(libexec)
+    system python3, *Language::Python.setup_install_args(libexec, python=python3)
 
     xy = Language::Python.major_minor_version python3
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/mopidy-podcast.rb
+++ b/Formula/mopidy-podcast.rb
@@ -28,11 +28,11 @@ class MopidyPodcast < Formula
 
     resources.each do |r|
       r.stage do
-        system python3, *Language::Python.setup_install_args(libexec)
+        system python3, *Language::Python.setup_install_args(libexec, python=python3)
       end
     end
 
-    system python3, *Language::Python.setup_install_args(libexec)
+    system python3, *Language::Python.setup_install_args(libexec, python=python3)
 
     xy = Language::Python.major_minor_version python3
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/mopidy-scrobbler.rb
+++ b/Formula/mopidy-scrobbler.rb
@@ -22,11 +22,11 @@ class MopidyScrobbler < Formula
 
     resources.each do |r|
       r.stage do
-        system python3, *Language::Python.setup_install_args(libexec)
+        system python3, *Language::Python.setup_install_args(libexec, python=python3)
       end
     end
 
-    system python3, *Language::Python.setup_install_args(libexec)
+    system python3, *Language::Python.setup_install_args(libexec, python=python3)
 
     xy = Language::Python.major_minor_version python3
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/mopidy-somafm.rb
+++ b/Formula/mopidy-somafm.rb
@@ -16,7 +16,7 @@ class MopidySomafm < Formula
   def install
     python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
-    system python3, *Language::Python.setup_install_args(libexec)
+    system python3, *Language::Python.setup_install_args(libexec, python=python3)
 
     xy = Language::Python.major_minor_version python3
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/mopidy-soundcloud.rb
+++ b/Formula/mopidy-soundcloud.rb
@@ -16,7 +16,7 @@ class MopidySoundcloud < Formula
   def install
     python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
-    system python3, *Language::Python.setup_install_args(libexec)
+    system python3, *Language::Python.setup_install_args(libexec, python=python3)
 
     xy = Language::Python.major_minor_version python3
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/mopidy-spotify.rb
+++ b/Formula/mopidy-spotify.rb
@@ -16,7 +16,7 @@ class MopidySpotify < Formula
   def install
     python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
-    system python3, *Language::Python.setup_install_args(libexec)
+    system python3, *Language::Python.setup_install_args(libexec, python=python3)
 
     xy = Language::Python.major_minor_version python3
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/mopidy-tunein.rb
+++ b/Formula/mopidy-tunein.rb
@@ -16,7 +16,7 @@ class MopidyTunein < Formula
   def install
     python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
-    system python3, *Language::Python.setup_install_args(libexec)
+    system python3, *Language::Python.setup_install_args(libexec, python=python3)
 
     xy = Language::Python.major_minor_version python3
     site_packages = "lib/python#{xy}/site-packages"

--- a/Formula/mopidy.rb
+++ b/Formula/mopidy.rb
@@ -48,11 +48,11 @@ class Mopidy < Formula
 
     resources.each do |r|
       r.stage do
-        system python3, *Language::Python.setup_install_args(libexec)
+        system python3, *Language::Python.setup_install_args(libexec, python=python3)
       end
     end
 
-    system python3, *Language::Python.setup_install_args(libexec)
+    system python3, *Language::Python.setup_install_args(libexec, python=python3)
 
     xy = Language::Python.major_minor_version python3
     site_packages = "lib/python#{xy}/site-packages"


### PR DESCRIPTION
This pull request updates formula files to explicitly specify Python 3.12 as an argument to the `Language::Python.setup_install_args` method. It seems this fixes #46.
