### PR TITLE
Add setuptool manual install

### DIFF
--- a/Formula/mopidy.rb
+++ b/Formula/mopidy.rb
@@ -44,6 +44,11 @@ class Mopidy < Formula
     sha256 "f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
   end
 
+  resource "setuptools" do
+    url "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz"
+    sha256 "22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb"
+  end
+
   def install
     python3 = Formula["python@3.12"].opt_bin/"python3.12"
 

--- a/Formula/mopidy.rb
+++ b/Formula/mopidy.rb
@@ -52,6 +52,11 @@ class Mopidy < Formula
   def install
     python3 = Formula["python@3.12"].opt_bin/"python3.12"
 
+    # hacky fix until 4.x mopidy is stable.
+    resource("setuptools").stage do
+      system python3, *Language::Python.setup_install_args(libexec, python=python3)
+    end
+
     resources.each do |r|
       r.stage do
         system python3, *Language::Python.setup_install_args(libexec, python=python3)


### PR DESCRIPTION

Problem:
- Mopidy still imports pkg_resources and pkg_resources comes from `setuptools`
- Python v3.12 does not auto add setuptools
- and Homebrew can't auto-inject setuptools into the isolated Python env
- trying to manually install missing packages into that environment (pip install setuptools) is blocked, and would be wiped/overwritten on updates

Solution: 
- add manual setup tools as extra resource.

Real solution:
- wait for mopidy 4.x release is stable for osx