### PR TITLE
Set up homebrew/core in autobump workflow

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@a657b8b0cd35d0f65cce41fce9b24cf054b49869 # 2026.08.24.1
+        with:
+          # brew bump loads formulas from homebrew/core (e.g. python@3.X)
+          # when regenerating a bumped formula's Python resources.
+          core: true
 
       - name: Set up git
         id: git_setup


### PR DESCRIPTION
Fixes the daily autobump failure (`No available formula with the name "python@3.14"`): `brew bump` loads formulas from homebrew/core when regenerating a bumped formula's Python resources, and the runner had no core tap.