### PR TITLE
Declare PyPI package exclusions for resource updates

### DIFF
--- a/Formula/mopidy-api-explorer.rb
+++ b/Formula/mopidy-api-explorer.rb
@@ -16,6 +16,8 @@ class MopidyApiExplorer < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   def install
     virtualenv_install_with_resources
 

--- a/Formula/mopidy-beets.rb
+++ b/Formula/mopidy-beets.rb
@@ -16,6 +16,8 @@ class MopidyBeets < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz"
     sha256 "741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55"

--- a/Formula/mopidy-internetarchive.rb
+++ b/Formula/mopidy-internetarchive.rb
@@ -16,6 +16,8 @@ class MopidyInternetarchive < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   resource "cachetools" do
     url "https://files.pythonhosted.org/packages/70/d2/47e8bc06fe2a06d3f5bdf20f1126ab66c4e99dc48d940e7ba873f7ac7131/cachetools-7.1.7.tar.gz"
     sha256 "a3e2a00b14d8f8a6b70c1dae7b4685e7ad3bc965c5b42124a2d6ce895da6cf50"

--- a/Formula/mopidy-listenbrainz.rb
+++ b/Formula/mopidy-listenbrainz.rb
@@ -16,6 +16,8 @@ class MopidyListenbrainz < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   resource "musicbrainzngs" do
     url "https://files.pythonhosted.org/packages/0a/67/3e74ae93d90ceeba72ed1a266dd3ca9abd625f315f0afd35f9b034acedd1/musicbrainzngs-0.7.1.tar.gz"
     sha256 "ab1c0100fd0b305852e65f2ed4113c6de12e68afd55186987b8ed97e0f98e627"

--- a/Formula/mopidy-local.rb
+++ b/Formula/mopidy-local.rb
@@ -16,6 +16,8 @@ class MopidyLocal < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   resource "uritools" do
     url "https://files.pythonhosted.org/packages/a3/0d/20d02264b6682f07e92cbf7ee43e5e803670d101a03ef204ba18368c321f/uritools-6.1.3.tar.gz"
     sha256 "3a498e7e85ef3249343d5710618d641a414da0fbae6d23053ada7976ee83ea5f"

--- a/Formula/mopidy-mpd.rb
+++ b/Formula/mopidy-mpd.rb
@@ -16,6 +16,8 @@ class MopidyMpd < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   def install
     virtualenv_install_with_resources
 

--- a/Formula/mopidy-nad.rb
+++ b/Formula/mopidy-nad.rb
@@ -16,6 +16,8 @@ class MopidyNad < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   resource "pyserial" do
     url "https://files.pythonhosted.org/packages/1e/7d/ae3f0a63f41e4d2f6cb66a5b57197850f919f59e558159a4dd3a818f5082/pyserial-3.5.tar.gz"
     sha256 "3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb"

--- a/Formula/mopidy-orfradio.rb
+++ b/Formula/mopidy-orfradio.rb
@@ -16,6 +16,8 @@ class MopidyOrfradio < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   resource "beaker" do
     url "https://files.pythonhosted.org/packages/83/6b/3cd3dcf40417e3be31a3a2257957144b0c058ffaf9ca32d2c83c85567cb6/beaker-1.14.1.tar.gz"
     sha256 "886f52a51810703fdbc0a3e54fca40886288ff530b2070582edce72bf1945447"

--- a/Formula/mopidy-pandora.rb
+++ b/Formula/mopidy-pandora.rb
@@ -16,6 +16,8 @@ class MopidyPandora < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   resource "blowfish" do
     url "https://files.pythonhosted.org/packages/ca/06/6008f79f3df714da4eeb6d7daf5e417e072c69923d22ede09171e74d69f8/blowfish-0.6.1.tar.bz2"
     sha256 "1626d96d2672a6cf021d9b66a5013b6e594865403b4a06d75034e0a9ff1cbdc6"

--- a/Formula/mopidy-pibox.rb
+++ b/Formula/mopidy-pibox.rb
@@ -16,6 +16,8 @@ class MopidyPibox < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   def install
     virtualenv_install_with_resources
 

--- a/Formula/mopidy-podcast-itunes.rb
+++ b/Formula/mopidy-podcast-itunes.rb
@@ -17,6 +17,8 @@ class MopidyPodcastItunes < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: %w[mopidy mopidy-podcast]
+
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz"
     sha256 "741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55"

--- a/Formula/mopidy-podcast.rb
+++ b/Formula/mopidy-podcast.rb
@@ -16,6 +16,8 @@ class MopidyPodcast < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   resource "cachetools" do
     url "https://files.pythonhosted.org/packages/70/d2/47e8bc06fe2a06d3f5bdf20f1126ab66c4e99dc48d940e7ba873f7ac7131/cachetools-7.1.7.tar.gz"
     sha256 "a3e2a00b14d8f8a6b70c1dae7b4685e7ad3bc965c5b42124a2d6ce895da6cf50"

--- a/Formula/mopidy-scrobbler.rb
+++ b/Formula/mopidy-scrobbler.rb
@@ -16,6 +16,8 @@ class MopidyScrobbler < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   resource "anyio" do
     url "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz"
     sha256 "cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f"

--- a/Formula/mopidy-somafm.rb
+++ b/Formula/mopidy-somafm.rb
@@ -16,6 +16,8 @@ class MopidySomafm < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   def install
     virtualenv_install_with_resources
 

--- a/Formula/mopidy-soundcloud.rb
+++ b/Formula/mopidy-soundcloud.rb
@@ -16,6 +16,8 @@ class MopidySoundcloud < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   resource "beautifulsoup4" do
     url "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz"
     sha256 "288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7"

--- a/Formula/mopidy-spotify.rb
+++ b/Formula/mopidy-spotify.rb
@@ -16,6 +16,8 @@ class MopidySpotify < Formula
   # The Python version must match the mopidy formula's.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "mopidy"
+
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz"
     sha256 "741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55"

--- a/Formula/mopidy.rb
+++ b/Formula/mopidy.rb
@@ -19,6 +19,8 @@ class Mopidy < Formula
   # The Python version must match the one gstreamer builds gst-python for.
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: "pygobject"
+
   resource "annotated-types" do
     url "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz"
     sha256 "13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7"

--- a/README.md
+++ b/README.md
@@ -129,15 +129,16 @@ If the new version changed its Python dependencies, regenerate the
 `resource` blocks:
 
 ```sh
-brew update-python-resources --exclude-packages=pygobject mopidy/mopidy/mopidy
+brew update-python-resources mopidy/mopidy/<formula>
 ```
 
-For extension formulas, also exclude everything provided by the mopidy
-formula's virtualenv:
-
-```sh
-brew update-python-resources --exclude-packages="mopidy pygobject pykka" mopidy/mopidy/<formula>
-```
+Every formula declares a `pypi_packages exclude_packages:` stanza, which
+both `brew update-python-resources` and `brew bump` use to leave out the
+packages that are provided by other formulas: the mopidy formula
+excludes `pygobject` (provided by `pygobject3`), and the extension
+formulas exclude `mopidy` (whose whole dependency tree they get from the
+mopidy formula's virtualenv at runtime). Excluding a package also prunes
+its entire dependency subtree.
 
 Caveats:
 
@@ -175,14 +176,17 @@ mopidy config
    (`mopidy-somafm.rb` has no extra resources, `mopidy-beets.rb` bundles
    a dependency tree).
 2. Set `desc`, `homepage`, `url` (PyPI sdist), `sha256`, and `license`.
-3. Generate resources as described above, excluding `mopidy`,
-   `pygobject`, and `pykka`.
-4. Keep the `.pth` block in `def install`, replacing the formula name in
+3. Keep the `pypi_packages exclude_packages: "mopidy"` stanza — it is
+   required for `brew bump` and `brew update-python-resources` to
+   generate correct resources. If the extension depends on another
+   extension formula, exclude that too.
+4. Generate resources as described above.
+5. Keep the `.pth` block in `def install`, replacing the formula name in
    the `.pth` filename.
-5. Point the `test` block's `assert_match` at the extension's config
+6. Point the `test` block's `assert_match` at the extension's config
    section name (check with `mopidy config` — it is usually, but not
    always, the extension name without the `mopidy-` prefix).
-6. Run the full local testing checklist above.
+7. Run the full local testing checklist above.
 
 ### Releasing (bottles)
 


### PR DESCRIPTION
Third and final piece of the autobump fix (after #58, #59): `brew bump` regenerates a bumped formula's Python resources, and without declared exclusions it inlines the full PyPI dependency tree — including mopidy's ~25 packages and pygobject — into every extension formula, which breaks this tap's design (extensions get those from the mopidy formula's virtualenv at runtime, and pygobject comes from pygobject3).

The `pypi_packages exclude_packages:` stanza is what `brew update-python-resources` and `brew bump` fall back to when no CLI flags are given, and excluding a package prunes its entire dependency subtree. Verified locally: a `brew bump-formula-pr --write-only --version=4.0.1 mopidy/mopidy/mopidy-pibox` now produces a diff containing exactly the url/sha256 change.

(The attrs lookup failure in the last run was transient PyPI throttling and needed no fix.)