### PR TITLE
Allow manually triggering the test-bot and autobump workflows

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     # Every day at 16:25 UTC
     - cron: 25 16 * * *
+  # Manual runs bump formulas on demand, e.g. right after an upstream
+  # release, instead of waiting for the daily scheduled run.
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+  # Manual runs check the tap syntax (brew style and audit) against
+  # current Homebrew; formulae are only built on pull requests.
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
Adds `workflow_dispatch` to:

- **autobump.yml** — bump formulas on demand right after an upstream release instead of waiting for the daily schedule, and test workflow changes without merging blind (this would have shortened today's debugging considerably).
- **tests.yml** — on-demand tap syntax check (`brew style`/`brew audit` against current Homebrew) without opening a throwaway PR. The formula build and bottle upload steps remain PR-only.

**publish.yml** is already manual-only and is unchanged.